### PR TITLE
Note timing rework, 'h', '$', '!' parsing for Simai

### DIFF
--- a/Chart/Chart.cs
+++ b/Chart/Chart.cs
@@ -841,6 +841,7 @@ public abstract class Chart : IChart
                     if (candidate.InternalSlides.Count > 0) slideCandidates.AddRange(candidate.InternalSlides);
                     break;
                 case NoteEnum.NoteSpecificGenre.SLIDE_GROUP:
+                    x.Update();
                     var groupCandidate = x as SlideGroup ??
                                          throw new InvalidOperationException("THIS IS NOT A SLIDE GROUP");
                     if (groupCandidate.InternalSlides.Count > 0) adjusted.AddRange(groupCandidate.InternalSlides);

--- a/Chart/Ma2.cs
+++ b/Chart/Ma2.cs
@@ -119,7 +119,8 @@ public class Ma2 : Chart, ICompiler
         builder.Append($"T_REC_ALL\t{AllNoteRecNum}\n");
 
         builder.Append($"T_NUM_TAP\t{TapNum}\n");
-        builder.Append($"T_NUM_BRK\t{HoldNum}\n");
+        builder.Append($"T_NUM_BRK\t{BreakNum}\n");
+        builder.Append($"T_NUM_HLD\t{HoldNum}\n");
         builder.Append($"T_NUM_SLD\t{SlideNum}\n");
         builder.Append($"T_NUM_ALL\t{AllNoteNum}\n");
 

--- a/Note/Hold.cs
+++ b/Note/Hold.cs
@@ -14,15 +14,35 @@ public class Hold : Note
     /// <param name="noteType">HLD,XHO</param>
     /// <param name="key">Key of the hold note</param>
     /// <param name="bar">Bar of the hold note</param>
-    /// <param name="startTime">Tick of the hold note</param>
-    /// <param name="lastTime">Last time of the hold note</param>
-    public Hold(NoteType noteType, int bar, int startTime, string key, int lastTime)
+    /// <param name="startTick">Tick of the hold note</param>
+    /// <param name="lastLength">Last time of the hold note in seconds</param>
+    public Hold(NoteType noteType, int bar, int startTick, string key, int lastLength)
     {
         NoteType = noteType;
         Key = key;
         Bar = bar;
-        Tick = startTime;
-        LastLength = lastTime;
+        Tick = startTick;
+        LastLength = lastLength;
+        SpecialEffect = false;
+        TouchSize = "M1";
+        Update();
+    }
+
+    /// <summary>
+    ///     Construct a Hold Note
+    /// </summary>
+    /// <param name="noteType">HLD,XHO</param>
+    /// <param name="key">Key of the hold note</param>
+    /// <param name="bar">Bar of the hold note</param>
+    /// <param name="startTick">Tick of the hold note</param>
+    /// <param name="lastLength">Last time of the hold note</param>
+    public Hold(NoteType noteType, int bar, int startTick, int lastSeconds, string key)
+    {
+        NoteType = noteType;
+        Key = key;
+        Bar = bar;
+        Tick = startTick;
+        CalculatedLastTime = lastSeconds;
         SpecialEffect = false;
         TouchSize = "M1";
         Update();

--- a/Note/Note.cs
+++ b/Note/Note.cs
@@ -215,8 +215,19 @@ public abstract class Note : IEquatable<Note>, INote, IComparable
     /// </summary>
     public double BPM { get; set; }
 
+    /// <summary>
+    /// The definition of the note which represented by the maximum tick of a 4/4 bar. By default it is 384.
+    /// </summary>
+    public int Definition { get; protected set; }
+
+    /// <summary>
+    /// Whether this note has a firework effect.
+    /// </summary>
     public bool SpecialEffect { get; protected set; }
 
+    /// <summary>
+    /// Determines the size of the touch. By default it is M1
+    /// </summary>
     public string TouchSize { get; protected set; }
 
     /// <summary>

--- a/Note/Slide.cs
+++ b/Note/Slide.cs
@@ -23,17 +23,42 @@ public class Slide : Note
     /// </param>
     /// <param name="key">0-7</param>
     /// <param name="bar">Bar in</param>
-    /// <param name="startTime">Start Time</param>
-    /// <param name="lastTime">Last Time</param>
+    /// <param name="startTick">Start Time</param>
+    /// <param name="lastLength">Last Time</param>
     /// <param name="endKey">0-7</param>
-    public Slide(NoteType noteType, int bar, int startTime, string key, int waitTime, int lastTime, string endKey)
+    public Slide(NoteType noteType, int bar, int startTick, string key, int waitLength, int lastLength, string endKey)
     {
         NoteType = noteType;
         Key = key;
         Bar = bar;
-        Tick = startTime;
-        WaitLength = waitTime;
-        LastLength = lastTime;
+        Tick = startTick;
+        WaitLength = waitLength;
+        LastLength = lastLength;
+        EndKey = endKey;
+        Delayed = WaitLength != 96;
+        Update();
+    }
+
+    /// <summary>
+    ///     Construct a Slide Note (Valid only if Start Key matches a start!)
+    /// </summary>
+    /// <param name="noteType">
+    ///     SI_(Straight),SCL,SCR,SV_(Line not intercepting Crossing Center),SUL,SUR,SF_(Wifi),SLL(Infecting
+    ///     Line),SLR(Infecting),SXL(Self winding),SXR(Self winding),SSL,SSR
+    /// </param>
+    /// <param name="key">0-7</param>
+    /// <param name="bar">Bar in</param>
+    /// <param name="startTick">Start Time</param>
+    /// <param name="lastLength">Last Time</param>
+    /// <param name="endKey">0-7</param>
+    public Slide(NoteType noteType, int bar, int startTick, int waitTime, int lastTime, string key, string endKey)
+    {
+        NoteType = noteType;
+        Key = key;
+        Bar = bar;
+        Tick = startTick;
+        CalculatedWaitTime = waitTime;
+        CalculatedLastTime = lastTime;
         EndKey = endKey;
         Delayed = WaitLength != 96;
         Update();

--- a/Note/SlideEachSet.cs
+++ b/Note/SlideEachSet.cs
@@ -27,6 +27,11 @@ public class SlideEachSet : Note
             var candidate = x as Slide ?? throw new InvalidOperationException("This is not a SLIDE");
             InternalSlides.Add(candidate);
         }
+        else if (x.NoteSpecificGenre is NoteSpecificGenre.SLIDE_GROUP)
+        {
+            var candidate = x as SlideGroup ?? throw new InvalidOperationException("This is not a SLIDE GROUP");
+            InternalSlides.Add(candidate);
+        }
 
         Update();
     }
@@ -170,8 +175,12 @@ public class SlideEachSet : Note
                 separateSymbol = "*";
                 if (InternalSlides.Count == 0 && SlideStart != null) result += SlideStart.Compose(format) + "$";
                 else if (InternalSlides.Count > 0 && SlideStart == null)
-                    result += new Tap(InternalSlides.First()).Compose(format) + "!";
+                    result += new Tap(InternalSlides.First()){NoteSpecialState = SpecialState.Normal}.Compose(format) + "!";
                 else if (SlideStart != null) result += SlideStart.Compose(format);
+                for (var i = 0; i < InternalSlides.Count; i++)
+                    if (i < InternalSlides.Count - 1)
+                        result += InternalSlides[i].Compose(format) + separateSymbol;
+                    else result += InternalSlides[i].Compose(format);
                 break;
             case ChartVersion.Ma2_103:
             case ChartVersion.Ma2_104:
@@ -184,16 +193,15 @@ public class SlideEachSet : Note
             default:
                 if (InternalSlides.Count == 0 && SlideStart != null) result += SlideStart.Compose(format) + "\n";
                 else if (InternalSlides.Count > 0 && SlideStart == null)
-                    result += new Tap(InternalSlides.First()).Compose(format) + "\n";
+                    result += new Tap(InternalSlides.First()){NoteSpecialState = SpecialState.Normal}.Compose(format) + "\n";
                 else if (SlideStart != null) result += SlideStart.Compose(format);
                 separateSymbol = "\n";
+                for (var i = 0; i < InternalSlides.Count; i++)
+                    if (i < InternalSlides.Count - 1)
+                        result += InternalSlides[i].Compose(format) + separateSymbol;
+                    else result += InternalSlides[i].Compose(format);
                 break;
         }
-
-        for (var i = 0; i < InternalSlides.Count; i++)
-            if (i < InternalSlides.Count - 1)
-                result += InternalSlides[i].Compose(format) + separateSymbol;
-            else result += InternalSlides[i].Compose(format);
 
         return result;
     }

--- a/Note/SlideGroup.cs
+++ b/Note/SlideGroup.cs
@@ -18,7 +18,7 @@ public class SlideGroup : Slide
         {
             (Slide)inTake
         };
-        NoteSpecialState = SpecialState.Normal;
+        NoteSpecialState = inTake.NoteSpecialState;
         Update();
     }
 
@@ -26,12 +26,12 @@ public class SlideGroup : Slide
     {
         InternalSlides = new List<Slide>();
         InternalSlides.AddRange(slideCandidate);
-        NoteSpecialState = SpecialState.Normal;
+        NoteSpecialState = slideCandidate.First().NoteSpecialState;
         Update();
     }
     #endregion
 
-    public int SlideCount => this == null ? 0 : InternalSlides.Count;
+    public int SlideCount => InternalSlides.Count;
 
     public override NoteSpecificGenre NoteSpecificGenre => NoteSpecificGenre.SLIDE_GROUP;
 
@@ -78,6 +78,7 @@ public class SlideGroup : Slide
         //     Console.WriteLine("Invalid slide group located at bar " + Bar + " tick " + Tick);
         //     throw new InvalidOperationException("MA2 IS NOT COMPATIBLE WITH SLIDE GROUP");
         // }
+        if (InternalSlides.Count > 0) InternalSlides.First().NoteSpecialState = NoteSpecialState;
         foreach (var x in InternalSlides)
             // Note localSlideStart = x.SlideStart != null ? x.SlideStart : new Tap("NST", x.Bar, x.Tick, x.Key);
             result += x.Compose(format);
@@ -105,6 +106,9 @@ public class SlideGroup : Slide
 
     public override bool Update()
     {
+        if (InternalSlides.Any(slide => slide.NoteSpecialState is SpecialState.Break))
+            NoteSpecialState = SpecialState.Break;
+        if (InternalSlides.Count > 0) InternalSlides.First().NoteSpecialState = NoteSpecialState;
         var result = false;
         if (SlideCount > 0 && InternalSlides.Last().LastLength == 0)
             throw new InvalidOperationException("THE LAST SLIDE IN THIS GROUP DOES NOT HAVE LAST TIME ASSIGNED");

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -121,9 +121,14 @@ public class SimaiParser : IParser
         {
             if (isSlide)
             {
+                bool containingBreak = token.Contains('b');
+                if (containingBreak) token = token.Replace("b", "");
+                SpecialState breakState = containingBreak ? SpecialState.Break : SpecialState.Normal;
                 List<string> extractedToken = ExtractConnectingSlides(token);
                 if (extractedToken.Count == 1) result = SlideOfToken(token, bar, tick, PreviousSlideStart, bpm);
                 else result = SlideGroupOfToken(extractedToken, bar, tick, PreviousSlideStart, bpm);
+                result.NoteSpecialState = breakState;
+                result.Update();
             }
             else if (isHold)
             {

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -149,6 +149,10 @@ public class SimaiParser : IParser
                 result = TapOfToken(token, bar, tick, bpm);
                 if (result.NoteSpecificGenre is NoteSpecificGenre.SLIDE_START) PreviousSlideStart = (Tap)result;
             }
+            else if (token.Contains('!'))
+            {
+                PreviousSlideStart = TapOfToken(token, bar, tick, bpm);
+            }
         }
 
         return result;
@@ -183,6 +187,7 @@ public class SimaiParser : IParser
             var keyCandidate = int.Parse(token.Substring(0, 1)) - 1;
             if (token.Contains('_')||token.Contains('$'))
                 result = new Tap(NoteType.STR, bar, tick, keyCandidate.ToString());
+            else if (token.Contains('!')) result = new Tap(NoteType.NST, bar, tick, keyCandidate.ToString());
             else result = new Tap(NoteType.TAP, bar, tick, keyCandidate.ToString());
             if (isEXBreak) result.NoteSpecialState = SpecialState.BreakEX;
             else if (isEXTap) result.NoteSpecialState = SpecialState.EX;

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -144,7 +144,7 @@ public class SimaiParser : IParser
                 var quaverCandidate = token.Replace("{", "").Replace("}", "");
                 result = new MeasureChange(bar, tick, int.Parse(quaverCandidate));
             }
-            else if (!token.Equals("E") && !token.Equals(""))
+            else if (!token.Contains('!') && !token.Equals("E") && !token.Equals(""))
             {
                 result = TapOfToken(token, bar, tick, bpm);
                 if (result.NoteSpecificGenre is NoteSpecificGenre.SLIDE_START) PreviousSlideStart = (Tap)result;
@@ -181,7 +181,7 @@ public class SimaiParser : IParser
         else
         {
             var keyCandidate = int.Parse(token.Substring(0, 1)) - 1;
-            if (token.Contains("_"))
+            if (token.Contains('_')||token.Contains('$'))
                 result = new Tap(NoteType.STR, bar, tick, keyCandidate.ToString());
             else result = new Tap(NoteType.TAP, bar, tick, keyCandidate.ToString());
             if (isEXBreak) result.NoteSpecialState = SpecialState.BreakEX;

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -115,7 +115,7 @@ public class SimaiParser : IParser
         var isBPM = token.Contains(")");
         var isMeasure = token.Contains("}");
         var isSlide = ContainsSlideNotation(token);
-        var isHold = !isSlide && token.Contains("[");
+        var isHold = !isSlide && token.Contains('h');
 
         if (!isRest)
         {
@@ -200,6 +200,7 @@ public class SimaiParser : IParser
 
     public Hold HoldOfToken(string token, int bar, int tick, double bpm)
     {
+        if (!token.Contains('[')) token += $"[{MaximumDefinition}:0]";
         var sustainSymbol = token.IndexOf("[");
         var keyCandidate = token.Substring(0, sustainSymbol); //key candidate is like tap grammar
         //Console.WriteLine(keyCandidate);
@@ -267,10 +268,7 @@ public class SimaiParser : IParser
         }
 
         //Console.WriteLine(key);
-        if (holdType.Equals("THO"))
-            candidate = new Hold(NoteType.THO, bar, tick, key, lastTick, specialEffect == 1, "M1");
-        else
-            candidate = new Hold(typeCandidate, bar, tick, key, lastTick);
+        candidate = holdType.Equals("THO") ? new Hold(NoteType.THO, bar, tick, key, lastTick, specialEffect == 1, "M1") : new Hold(typeCandidate, bar, tick, key, lastTick);
         candidate.BPM = bpm;
         candidate.NoteSpecialState = specialState;
         return candidate;


### PR DESCRIPTION
Added parsing for `h (without duration specification)` - closes #34
Added parsing for `$` (Single slide start), and `!` (Slide without slide start) - closes #35 