### PR TITLE
Slide timing and EachGroupOfToken rework

### DIFF
--- a/MaiLib.csproj
+++ b/MaiLib.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Version>1.0.7.0</Version>
+        <Version>1.0.7.1</Version>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -796,30 +796,31 @@ public class SimaiParser : IParser
             int actualSlidePart = result.Count(p => !p.Contains('_'));
             double originalWaitDuration = 0.0;
             double averageDuration = 0.0;
-            // bool isMeasureDuration =
-            //     newDurationCandidate.Contains(':') && !newDurationCandidate.Contains('#'); // [Quaver : Beats]
-            // if (isMeasureDuration)
-            // {
-            //     string durationCandidate = newDurationCandidate.Replace("[", "").Replace("]", "");
-            //     string[] numList = durationCandidate.Split(':');
-            //     int quaver = int.Parse(numList[0]) * actualSlidePart;
-            //     int multiple = int.Parse(numList[1]);
-            //     newDurationCandidate = $"[{quaver}:{multiple}]";
-            // }
-            // else
-            // {
-            //     double[] durationResult = GetTimeCandidates(newDurationCandidate);
-            //     originalWaitDuration = durationResult[0];
-            //     averageDuration = durationResult[1] / actualSlidePart;
-            //     newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
-            // }
+            bool isMeasureDuration =
+                newDurationCandidate.Contains(':') && !newDurationCandidate.Contains('#'); // [Quaver : Beats]
+            if (isMeasureDuration)
+            {
+                string durationCandidate = newDurationCandidate.Replace("[", "").Replace("]", "");
+                string[] numList = durationCandidate.Split(':');
+                int quaver = int.Parse(numList[0]) * actualSlidePart;
+                int multiple = int.Parse(numList[1]);
+                newDurationCandidate = $"[{quaver}:{multiple}]";
+            }
+            else
+            {
+                double[] durationResult = GetTimeCandidates(0.0, newDurationCandidate, true);
+                originalWaitDuration = durationResult[0];
+                averageDuration = durationResult[1] / actualSlidePart;
+                newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
+            }
 
-            double[] durationResult = GetTimeCandidates(0.0, newDurationCandidate, true);
-            originalWaitDuration = durationResult[0];
-            averageDuration = durationResult[1] / actualSlidePart;
-            newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
+            // double[] durationResult = GetTimeCandidates(0.0, newDurationCandidate, true);
+            // originalWaitDuration = durationResult[0];
+            // averageDuration = durationResult[1] / actualSlidePart;
+            // newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
 
-            bool writeOriginalWaitTime = true; // This trigger is only used once
+            bool writeOriginalWaitTime = !isMeasureDuration;
+            // bool writeOriginalWaitTime = true; // This trigger is only used once
             for (int i = result[0].Contains('_') ? 1 : 0; i < result.Count; i++)
             {
                 if (writeOriginalWaitTime)

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -905,7 +905,8 @@ public class SimaiParser : IParser
             throw new InvalidOperationException("GIVEN CANDIDATE DOES NOT CONTAIN DURATION SYMBOL [ AND ]");
         string durationCandidate = input.Replace("[", "").Replace("]", "");
         bool isMeasureDuration = input.Contains(':') && !input.Contains('#'); // [Quaver : Beats]
-
+        bool isSlideBpmMeasureDuration =
+            input.Contains("##") && input.Contains('#') && input.Contains(':'); // [WaitTime ## BPM # Quaver : Beats]
         if (isMeasureDuration && isSlide)
         {
             double quaver = double.Parse(durationCandidate.Split(':')[0]);

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -560,7 +560,7 @@ public class SimaiParser : IParser
                 break;
             case '(':
             case '{':
-                extractedParts.Add(buffer);
+                if (buffer.Length > 0) extractedParts.Add(buffer);
                 buffer = c.ToString();
                 break;
             case ')':

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -747,25 +747,30 @@ public class SimaiParser : IParser
             int actualSlidePart = result.Count(p => !p.Contains('_'));
             double originalWaitDuration = 0.0;
             double averageDuration = 0.0;
-            bool isMeasureDuration =
-                newDurationCandidate.Contains(':') && !newDurationCandidate.Contains('#'); // [Quaver : Beats]
-            if (isMeasureDuration)
-            {
-                string durationCandidate = newDurationCandidate.Replace("[", "").Replace("]", "");
-                string[] numList = durationCandidate.Split(':');
-                int quaver = int.Parse(numList[0]) * actualSlidePart;
-                int multiple = int.Parse(numList[1]);
-                newDurationCandidate = $"[{quaver}:{multiple}]";
-            }
-            else
-            {
-                double[] durationResult = GetTimeCandidates(newDurationCandidate);
-                originalWaitDuration = durationResult[0];
-                averageDuration = durationResult[1] / actualSlidePart;
-                newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
-            }
+            // bool isMeasureDuration =
+            //     newDurationCandidate.Contains(':') && !newDurationCandidate.Contains('#'); // [Quaver : Beats]
+            // if (isMeasureDuration)
+            // {
+            //     string durationCandidate = newDurationCandidate.Replace("[", "").Replace("]", "");
+            //     string[] numList = durationCandidate.Split(':');
+            //     int quaver = int.Parse(numList[0]) * actualSlidePart;
+            //     int multiple = int.Parse(numList[1]);
+            //     newDurationCandidate = $"[{quaver}:{multiple}]";
+            // }
+            // else
+            // {
+            //     double[] durationResult = GetTimeCandidates(newDurationCandidate);
+            //     originalWaitDuration = durationResult[0];
+            //     averageDuration = durationResult[1] / actualSlidePart;
+            //     newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
+            // }
 
-            bool writeOriginalWaitTime = newDurationCandidate.Contains("##");
+            double[] durationResult = GetTimeCandidates(0.0, newDurationCandidate, true);
+            originalWaitDuration = durationResult[0];
+            averageDuration = durationResult[1] / actualSlidePart;
+            newDurationCandidate = $"[0##{Math.Round(averageDuration, 4)}]";
+
+            bool writeOriginalWaitTime = true; // This trigger is only used once
             for (int i = result[0].Contains('_') ? 1 : 0; i < result.Count; i++)
             {
                 if (writeOriginalWaitTime)

--- a/Parser/Simaiparser.cs
+++ b/Parser/Simaiparser.cs
@@ -500,49 +500,6 @@ public class SimaiParser : IParser
 
     #region HeroticStaticHelperMethods
 
-    public static List<string> OldEachGroupOfToken(string token)
-    {
-        List<string>? result = new List<string>();
-        bool isSlide = ContainsSlideNotation(token);
-        if (token.Contains("/"))
-        {
-            string[]? candidate = token.Split("/");
-            foreach (string? tokenCandidate in candidate) result.AddRange(EachGroupOfToken(tokenCandidate));
-        }
-        else if (token.Contains('`'))
-        {
-            string candidate = token.Replace("`", "%/");
-            result.AddRange(EachGroupOfToken(candidate));
-        }
-        else if (token.Contains(')') || token.Contains('}'))
-        {
-            List<string>? resultCandidate = ExtractParentheses(token);
-            List<string> fixedCandidate = new();
-            foreach (string? candidate in resultCandidate) fixedCandidate.AddRange(ExtractParentheses(candidate));
-            foreach (string? candidate in fixedCandidate) result.AddRange(ExtractEachSlides(candidate));
-        } //lol this is the most stupid code I have ever wrote
-        else if (int.TryParse(token, out int eachPair))
-        {
-            char[]? eachPairs = token.ToCharArray();
-            foreach (char x in eachPairs) result.Add(x.ToString());
-        }
-        else if (isSlide)
-        {
-            //List<string> candidate = EachGroupOfToken(token);
-            //foreach (string item in candidate)
-            //{
-            //    result.AddRange(ExtractEachSlides(item));
-            //}
-            result.AddRange(ExtractEachSlides(token));
-        }
-        else
-        {
-            result.Add(token);
-        }
-
-        return result;
-    }
-
     /// <summary>
     ///     Deal with old, out-fashioned and illogical Simai Each Groups. Reworked with state machine.
     /// </summary>
@@ -552,32 +509,33 @@ public class SimaiParser : IParser
     {
         string buffer = "";
         List<string> extractedParts = new();
-        foreach (char c in token) switch (c)
-        {
-            case '/':
-                extractedParts.Add(buffer);
-                buffer = "";
-                break;
-            case '(':
-            case '{':
-                if (buffer.Length > 0) extractedParts.Add(buffer);
-                buffer = c.ToString();
-                break;
-            case ')':
-            case '}':
-                buffer += c;
-                extractedParts.Add(buffer);
-                buffer = "";
-                break;
-            case '`':
-                buffer += '%'; // Might not be necessary since this method is reworked
-                extractedParts.Add(buffer);
-                buffer = "";
-                break;
-            default:
-                buffer += c;
-                break;
-        }
+        foreach (char c in token)
+            switch (c)
+            {
+                case '/':
+                    extractedParts.Add(buffer);
+                    buffer = "";
+                    break;
+                case '(':
+                case '{':
+                    if (buffer.Length > 0) extractedParts.Add(buffer);
+                    buffer = c.ToString();
+                    break;
+                case ')':
+                case '}':
+                    buffer += c;
+                    extractedParts.Add(buffer);
+                    buffer = "";
+                    break;
+                case '`':
+                    buffer += '%'; // Might not be necessary since this method is reworked
+                    extractedParts.Add(buffer);
+                    buffer = "";
+                    break;
+                default:
+                    buffer += c;
+                    break;
+            }
 
         if (buffer.Length > 0) extractedParts.Add(buffer);
 
@@ -594,6 +552,7 @@ public class SimaiParser : IParser
             }
             else result.Add(part);
         }
+
         return result;
     }
 
@@ -924,8 +883,12 @@ public class SimaiParser : IParser
         else if (isHoldTimedDuration)
         {
             bool isSlideReassignedFormat = durationCandidate.Split('#')[0].Length != 0;
-            result[0] = isSlideReassignedFormat ? Chart.GetBPMTimeUnit(double.Parse(durationCandidate.Split('#')[0]), MaximumDefinition) * 96 : 0;
-            result[1] = isSlideReassignedFormat ? double.Parse(durationCandidate.Split('#')[1]) : double.Parse(durationCandidate.Replace("#", ""));
+            result[0] = isSlideReassignedFormat
+                ? Chart.GetBPMTimeUnit(double.Parse(durationCandidate.Split('#')[0]), MaximumDefinition) * 96
+                : 0;
+            result[1] = isSlideReassignedFormat
+                ? double.Parse(durationCandidate.Split('#')[1])
+                : double.Parse(durationCandidate.Replace("#", ""));
             return result;
         }
         else if (isSlideBpmMeasureDuration)
@@ -979,7 +942,6 @@ public class SimaiParser : IParser
             double waitTimeCandidate =
                 Chart.GetBPMTimeUnit(bpm, MaximumDefinition) * 96;
             result[0] = waitTimeCandidate;
-
         }
         else if (isHoldBpmMeasureDuration && isSlide)
         {
@@ -988,6 +950,7 @@ public class SimaiParser : IParser
                 Chart.GetBPMTimeUnit(bpmCandidate, MaximumDefinition) * 96;
             result[0] = waitTimeCandidate;
         }
+
         return result;
     }
 


### PR DESCRIPTION
- Start wiping all individual duration handlers and replacing with new handler - closes #41 
- Revised connecting slide duration setting - closes #42 
- Revised `EachGroupOfToken()` in `SimaiParser`: this finite state machine handler should make parsing easier - closes #43
- Problem from `MaichartConverter` should alsio be fixed - closes Neskol/MaichartConverter#19
