### PR TITLE
fix: connectingSlide LastLength calculation error

### DIFF
--- a/Note/Note.cs
+++ b/Note/Note.cs
@@ -900,7 +900,9 @@ public abstract class Note : IEquatable<Note>, INote, IComparable
 
         if (CalculatedLastTime != 0 && LastLength == 0)
         {
-            int tickCandidate = NoteGenre is NoteGenre.HOLD ? TickStamp : WaitTickStamp;
+            int tickCandidate = TickStamp;
+            // If slide has wait time, use WaitTickStamp (= TickStamp + CalculatedWaitTime) instead
+            if (NoteGenre is NoteGenre.SLIDE && WaitTickStamp != 0) tickCandidate = WaitTickStamp;
             LastTimeStamp = GetTimeStamp(tickCandidate) + CalculatedLastTime;
             LastTickStamp = GetTickStampByTime(LastTimeStamp);
             LastLength = LastTickStamp - tickCandidate;


### PR DESCRIPTION
See https://github.com/clansty/MaiChartManager/issues/20

In Note.cs:901, `tickCandidate` is assigned to `TickStamp` for HOLD and `WaitTickStamp` for Slide.
https://github.com/Neskol/MaiLib/blob/b28f2fae3ab8c48cee88c033edbd72993c1c262d/Note/Note.cs#L901-L907

However, `connectingSlide` does not have wait time either. So `TickStamp` instead of `WaitTickStamp` (always=0 in such situation) should be used, or `LastTimeStamp` and `LastLength` would be wrongly calculated to a very small number. This may cause problem when there are bpm changes in the chart, such as in [this issue](https://github.com/clansty/MaiChartManager/issues/20).